### PR TITLE
extract runID from job for logging

### DIFF
--- a/cadc-uws-server/build.gradle
+++ b/cadc-uws-server/build.gradle
@@ -14,7 +14,7 @@ sourceCompatibility = 1.7
 
 group = 'org.opencadc'
 
-version = '1.1.1'
+version = '1.1.2'
 
 // Allow override of user.name (-Duser.name=uws).  Useful to connect to a PostgreSQL Docker container.
 test {
@@ -30,7 +30,7 @@ dependencies {
     compile 'org.restlet.jee:org.restlet.ext.fileupload:2.0.2'
     compile 'org.springframework:spring-jdbc:2.5.6.SEC01'
 
-    compile 'org.opencadc:cadc-log:1.+'
+    compile 'org.opencadc:cadc-log:[1.0.6,)'
     compile 'org.opencadc:cadc-util:[1.1,)'
     compile 'org.opencadc:cadc-vosi:1.+'
     compile 'org.opencadc:cadc-uws:[1.0.1,)'

--- a/cadc-uws-server/src/main/java/ca/nrc/cadc/uws/util/JobLogInfo.java
+++ b/cadc-uws-server/src/main/java/ca/nrc/cadc/uws/util/JobLogInfo.java
@@ -95,6 +95,7 @@ public class JobLogInfo extends WebServiceLogInfo
         this.from = job.getRemoteIP();
         this.path = job.getRequestPath();
         this.user = getUser(job.ownerSubject);
+        this.runID = job.getRunID();
         setJobID(job.getID());
     }
 

--- a/cadc-uws-server/src/test/java/ca/nrc/cadc/uws/util/JobLogInfoTest.java
+++ b/cadc-uws-server/src/test/java/ca/nrc/cadc/uws/util/JobLogInfoTest.java
@@ -28,9 +28,9 @@
 
 package ca.nrc.cadc.uws.util;
 
-import junit.framework.Assert;
 
 import org.easymock.EasyMock;
+import org.junit.Assert;
 import org.junit.Test;
 
 import ca.nrc.cadc.log.WebServiceLogInfo;
@@ -46,17 +46,18 @@ public class JobLogInfoTest
         EasyMock.expect(job.getRemoteIP()).andReturn("192.168.0.0").once();
         EasyMock.expect(job.getRequestPath()).andReturn("/path/of/request").once();
         EasyMock.expect(job.getID()).andReturn("jobid").once();
+        EasyMock.expect(job.getRunID()).andReturn("runid").once();
         job.ownerSubject = null;
         
         EasyMock.replay(job);
         
         WebServiceLogInfo logInfo = new JobLogInfo(job);
         String start = logInfo.start();
-        Assert.assertEquals("Wrong start", "START: {\"method\":\"UWS\",\"path\":\"/path/of/request\",\"user\":\"anonUser\",\"from\":\"192.168.0.0\",\"jobID\":\"jobid\"}", start);
+        Assert.assertEquals("Wrong start", "START: {\"method\":\"UWS\",\"path\":\"/path/of/request\",\"user\":\"anonUser\",\"from\":\"192.168.0.0\",\"jobID\":\"jobid\",\"runID\":\"runid\"}", start);
         logInfo.setElapsedTime(1234L);
         logInfo.setMessage("the message");
         String end = logInfo.end();
-        Assert.assertEquals("Wrong end", "END: {\"method\":\"UWS\",\"path\":\"/path/of/request\",\"success\":true,\"user\":\"anonUser\",\"from\":\"192.168.0.0\",\"time\":1234,\"message\":\"the message\",\"jobID\":\"jobid\"}", end);
+        Assert.assertEquals("Wrong end", "END: {\"method\":\"UWS\",\"path\":\"/path/of/request\",\"success\":true,\"user\":\"anonUser\",\"from\":\"192.168.0.0\",\"time\":1234,\"message\":\"the message\",\"jobID\":\"jobid\",\"runID\":\"runid\"}", end);
         
         EasyMock.verify(job);
     }


### PR DESCRIPTION
Needs cadc-log 1.0.5 to be published in order to build without error.