### PR TITLE
changed JobPersistence to extend JobUpdater

### DIFF
--- a/cadc-uws-server/build.gradle
+++ b/cadc-uws-server/build.gradle
@@ -16,7 +16,7 @@ sourceCompatibility = 1.7
 
 group = 'org.opencadc'
 
-version = '1.2.1'
+version = '1.2.2'
 
 // Allow override of user.name (-Duser.name=uws).  Useful to connect to a PostgreSQL Docker container.
 test {

--- a/cadc-uws-server/src/main/java/ca/nrc/cadc/uws/server/JobPersistence.java
+++ b/cadc-uws-server/src/main/java/ca/nrc/cadc/uws/server/JobPersistence.java
@@ -3,7 +3,7 @@
 *******************  CANADIAN ASTRONOMY DATA CENTRE  *******************
 **************  CENTRE CANADIEN DE DONNÉES ASTRONOMIQUES  **************
 *
-*  (c) 2009.                            (c) 2009.
+*  (c) 2019.                            (c) 2019.
 *  Government of Canada                 Gouvernement du Canada
 *  National Research Council            Conseil national de recherches
 *  Ottawa, Canada, K1A 0R6              Ottawa, Canada, K1A 0R6
@@ -69,23 +69,22 @@
 
 package ca.nrc.cadc.uws.server;
 
-import java.util.Date;
-import java.util.Iterator;
-import java.util.List;
-
 import ca.nrc.cadc.net.TransientException;
 import ca.nrc.cadc.uws.ExecutionPhase;
 import ca.nrc.cadc.uws.Job;
 import ca.nrc.cadc.uws.JobRef;
 import ca.nrc.cadc.uws.Parameter;
+import java.util.Date;
+import java.util.Iterator;
+import java.util.List;
 
 /**
  * Service interface for job persistence.
  */
-public interface JobPersistence
-{
+public interface JobPersistence extends JobUpdater {
     /**
      * Shutdown and release any resources. This includes ThreadPools, connections, open files, etc.
+     * @throws java.lang.InterruptedException
      */
     public void terminate()
         throws InterruptedException;
@@ -139,7 +138,10 @@ public interface JobPersistence
     /**
      * Obtain a listing of JobRef instances.
      *
+     * @param appname
      * @return iterator over visible jobs
+     * @throws ca.nrc.cadc.uws.server.JobPersistenceException
+     * @throws ca.nrc.cadc.net.TransientException
      */
     public Iterator<JobRef> iterator(String appname)
         throws JobPersistenceException, TransientException;
@@ -147,8 +149,11 @@ public interface JobPersistence
     /**
      * Obtain a listing of JobRef instances in the specified phase.
      *
+     * @param appname
      * @param phases
      * @return iterator over visible jobs
+     * @throws ca.nrc.cadc.uws.server.JobPersistenceException
+     * @throws ca.nrc.cadc.net.TransientException
      */
     public Iterator<JobRef> iterator(String appname, List<ExecutionPhase> phases)
         throws JobPersistenceException, TransientException;
@@ -157,10 +162,13 @@ public interface JobPersistence
      * Obtain a listing of the last 'last' JobRef instances in the specified
      * phase with a start date after 'after'.
      *
+     * @param appname
      * @param phases
      * @param after
      * @param last
      * @return iterator over visible jobs
+     * @throws ca.nrc.cadc.uws.server.JobPersistenceException
+     * @throws ca.nrc.cadc.net.TransientException
      */
     public Iterator<JobRef> iterator(String appname, List<ExecutionPhase> phases, Date after, Integer last)
         throws JobPersistenceException, TransientException;
@@ -178,8 +186,4 @@ public interface JobPersistence
      */
     public void addParameters(String jobID, List<Parameter> params)
         throws JobNotFoundException, JobPersistenceException, TransientException;
-
-    // not needed by any current use cases
-    //public void setJobInfo(String jobID, JobInfo info)
-    //    throws JobNotFoundException;
 }

--- a/cadc-uws-server/src/main/java/ca/nrc/cadc/uws/server/JobUpdater.java
+++ b/cadc-uws-server/src/main/java/ca/nrc/cadc/uws/server/JobUpdater.java
@@ -3,7 +3,7 @@
 *******************  CANADIAN ASTRONOMY DATA CENTRE  *******************
 **************  CENTRE CANADIEN DE DONNÉES ASTRONOMIQUES  **************
 *
-*  (c) 2009.                            (c) 2009.
+*  (c) 2019.                            (c) 2019.
 *  Government of Canada                 Gouvernement du Canada
 *  National Research Council            Conseil national de recherches
 *  Ottawa, Canada, K1A 0R6              Ottawa, Canada, K1A 0R6
@@ -77,12 +77,13 @@ import java.util.Date;
 import java.util.List;
 
 /**
- *
+ * Interface to define the subset of the JobPersistence API that is intended for use by
+ * JobRunner implementations.
+ * 
  * @author pdowler
  */
-public interface JobUpdater
-{
-     /**
+public interface JobUpdater {
+    /**
      * Get the current execution phase of the specified job.
      *
      * @param jobID

--- a/cadc-uws-server/src/main/java/ca/nrc/cadc/uws/server/RequestPathJobManager.java
+++ b/cadc-uws-server/src/main/java/ca/nrc/cadc/uws/server/RequestPathJobManager.java
@@ -3,7 +3,7 @@
 *******************  CANADIAN ASTRONOMY DATA CENTRE  *******************
 **************  CENTRE CANADIEN DE DONNÉES ASTRONOMIQUES  **************
 *
-*  (c) 2018.                            (c) 2018.
+*  (c) 2019.                            (c) 2019.
 *  Government of Canada                 Gouvernement du Canada
 *  National Research Council            Conseil national de recherches
 *  Ottawa, Canada, K1A 0R6              Ottawa, Canada, K1A 0R6
@@ -69,24 +69,8 @@
 
 package ca.nrc.cadc.uws.server;
 
-import ca.nrc.cadc.auth.AuthenticationUtil;
-import ca.nrc.cadc.net.TransientException;
-import ca.nrc.cadc.rest.SyncOutput;
-import ca.nrc.cadc.uws.ExecutionPhase;
-import ca.nrc.cadc.uws.Job;
-import ca.nrc.cadc.uws.JobRef;
-import ca.nrc.cadc.uws.Parameter;
-import java.security.AccessControlContext;
-import java.security.AccessControlException;
-import java.security.AccessController;
-import java.security.Principal;
-import java.util.Date;
-import java.util.Iterator;
-import java.util.List;
 import java.util.Map;
-import java.util.Set;
 import java.util.TreeMap;
-import javax.security.auth.Subject;
 import org.apache.log4j.Logger;
 
 /**
@@ -140,9 +124,10 @@ public class RequestPathJobManager extends SimpleJobManager {
      * for one or more sub-paths.
      * 
      * @param requestPath
+     * @param jobUpdater
      * @return a JobExecutor instance
      */
-    protected JobExecutor createJobExecutor(String requestPath) {
+    protected JobExecutor createJobExecutor(String requestPath, JobUpdater jobUpdater) {
         return null;
     }
     
@@ -160,12 +145,12 @@ public class RequestPathJobManager extends SimpleJobManager {
     }
     
     @Override
-    protected JobExecutor getJobExecutor(String requestPath) {
-        JobExecutor ret = super.getJobExecutor(requestPath);
+    protected JobExecutor getJobExecutor(String requestPath, JobUpdater jobUpdater) {
+        JobExecutor ret = super.getJobExecutor(requestPath, jobUpdater);
         if (ret == null) {
             ret = jobExecutorMap.get(requestPath);
             if (ret == null) {
-                ret = createJobExecutor(requestPath);
+                ret = createJobExecutor(requestPath, jobUpdater);
                 jobExecutorMap.put(requestPath, ret);
             }
         }

--- a/cadc-uws-server/src/main/java/ca/nrc/cadc/uws/server/SimpleJobManager.java
+++ b/cadc-uws-server/src/main/java/ca/nrc/cadc/uws/server/SimpleJobManager.java
@@ -3,7 +3,7 @@
 *******************  CANADIAN ASTRONOMY DATA CENTRE  *******************
 **************  CENTRE CANADIEN DE DONNÉES ASTRONOMIQUES  **************
 *
-*  (c) 2018.                            (c) 2018.
+*  (c) 2019.                            (c) 2019.
 *  Government of Canada                 Gouvernement du Canada
 *  National Research Council            Conseil national de recherches
 *  Ottawa, Canada, K1A 0R6              Ottawa, Canada, K1A 0R6
@@ -82,9 +82,7 @@ import java.security.Principal;
 import java.util.Date;
 import java.util.Iterator;
 import java.util.List;
-import java.util.Map;
 import java.util.Set;
-import java.util.TreeMap;
 import javax.security.auth.Subject;
 import org.apache.log4j.Logger;
 
@@ -139,7 +137,7 @@ public class SimpleJobManager implements JobManager {
         return null;
     }
     
-    protected JobExecutor getJobExecutor(String requestPath) {
+    protected JobExecutor getJobExecutor(String requestPath, JobUpdater jobUpdater) {
         if (jobExecutorImpl != null) {
             return jobExecutorImpl;
         }
@@ -182,7 +180,7 @@ public class SimpleJobManager implements JobManager {
         JobPersistence jobPersistence = getJobPersistence(requestPath);
         Job job = jobPersistence.get(jobID);
         doAuthorizationCheck(job);
-        JobExecutor jobExecutor = getJobExecutor(requestPath);
+        JobExecutor jobExecutor = getJobExecutor(requestPath, jobPersistence);
         jobExecutor.abort(job);
     }
 
@@ -220,7 +218,7 @@ public class SimpleJobManager implements JobManager {
     public void execute(String requestPath, Job job)
             throws JobNotFoundException, JobPersistenceException, JobPhaseException, TransientException {
         // get does auth check and getDetails
-        JobExecutor jobExecutor = getJobExecutor(requestPath);
+        JobExecutor jobExecutor = getJobExecutor(requestPath, getJobPersistence(requestPath));
         jobExecutor.execute(job);
     }
 
@@ -237,7 +235,7 @@ public class SimpleJobManager implements JobManager {
     @Override
     public void execute(String requestPath, Job job, SyncOutput output)
             throws JobNotFoundException, JobPersistenceException, JobPhaseException, TransientException {
-        JobExecutor jobExecutor = getJobExecutor(requestPath);
+        JobExecutor jobExecutor = getJobExecutor(requestPath, getJobPersistence(requestPath));
         jobExecutor.execute(job, output);
     }
 


### PR DESCRIPTION
JobUpdater is now a subset API for use by JobRunner impls

changed getJobExecutor and createJobExecutor to take JobPersistence arg since executor needs to pass a JobUpdater to the JobRunner at execution time