### PR TITLE
Force ownerID to be a string

### DIFF
--- a/cadc-uws-server/src/main/java/ca/nrc/cadc/uws/server/JobDAO.java
+++ b/cadc-uws-server/src/main/java/ca/nrc/cadc/uws/server/JobDAO.java
@@ -1242,7 +1242,7 @@ public class JobDAO
             if (owner != null)
             {
                 log.debug(arg + " : " + owner);
-                ret.setObject(arg++, owner);
+                ret.setString(arg++, owner.toString());
             }
 
             if (phases != null && !phases.isEmpty())


### PR DESCRIPTION
Using the postgres UWS backend, I noticed that the scanning of jobs
would use an integer value of the ownerID rather than a string version,
which is what the postgres column type is.  This would throw a nasty
exception about not being able to convert between varchar and int

Not exactly sure if this is right, or if there's something missing in my auth implementation, but with this small change, everything I have works.