### PR TITLE
CADC-10839: move addParameters() from JobPersistence to JobUpdater interface

### DIFF
--- a/cadc-uws-server/build.gradle
+++ b/cadc-uws-server/build.gradle
@@ -15,7 +15,7 @@ sourceCompatibility = 1.8
 
 group = 'org.opencadc'
 
-version = '1.2.11'
+version = '1.2.12'
 
 description = 'OpenCADC UWS server library'
 def git_url = 'https://github.com/opencadc/uws'

--- a/cadc-uws-server/src/main/java/ca/nrc/cadc/uws/server/JobPersistence.java
+++ b/cadc-uws-server/src/main/java/ca/nrc/cadc/uws/server/JobPersistence.java
@@ -73,7 +73,6 @@ import ca.nrc.cadc.net.TransientException;
 import ca.nrc.cadc.uws.ExecutionPhase;
 import ca.nrc.cadc.uws.Job;
 import ca.nrc.cadc.uws.JobRef;
-import ca.nrc.cadc.uws.Parameter;
 import java.util.Date;
 import java.util.Iterator;
 import java.util.List;
@@ -173,17 +172,4 @@ public interface JobPersistence extends JobUpdater {
     public Iterator<JobRef> iterator(String requestPath, List<ExecutionPhase> phases, Date after, Integer last)
         throws JobPersistenceException, TransientException;
 
-    // optimised access methods
-
-    /**
-     * Add parameters to the specified job.
-     *
-     * @param jobID
-     * @param params
-     * @throws JobNotFoundException
-     * @throws JobPersistenceException
-     * @throws TransientException
-     */
-    public void addParameters(String jobID, List<Parameter> params)
-        throws JobNotFoundException, JobPersistenceException, TransientException;
 }

--- a/cadc-uws-server/src/main/java/ca/nrc/cadc/uws/server/JobUpdater.java
+++ b/cadc-uws-server/src/main/java/ca/nrc/cadc/uws/server/JobUpdater.java
@@ -3,7 +3,7 @@
 *******************  CANADIAN ASTRONOMY DATA CENTRE  *******************
 **************  CENTRE CANADIEN DE DONNÉES ASTRONOMIQUES  **************
 *
-*  (c) 2019.                            (c) 2019.
+*  (c) 2022.                            (c) 2022.
 *  Government of Canada                 Gouvernement du Canada
 *  National Research Council            Conseil national de recherches
 *  Ottawa, Canada, K1A 0R6              Ottawa, Canada, K1A 0R6
@@ -72,6 +72,7 @@ package ca.nrc.cadc.uws.server;
 import ca.nrc.cadc.net.TransientException;
 import ca.nrc.cadc.uws.ErrorSummary;
 import ca.nrc.cadc.uws.ExecutionPhase;
+import ca.nrc.cadc.uws.Parameter;
 import ca.nrc.cadc.uws.Result;
 import java.util.Date;
 import java.util.List;
@@ -162,5 +163,17 @@ public interface JobUpdater {
      * @throws TransientException 
      */
     public ExecutionPhase setPhase(String jobID, ExecutionPhase start, ExecutionPhase end, ErrorSummary error, Date date)
+        throws JobNotFoundException, JobPersistenceException, TransientException;
+
+    /**
+     * Add parameters to the specified job.
+     *
+     * @param jobID
+     * @param params
+     * @throws JobNotFoundException
+     * @throws JobPersistenceException
+     * @throws TransientException
+     */
+    public void addParameters(String jobID, List<Parameter> params)
         throws JobNotFoundException, JobPersistenceException, TransientException;
 }

--- a/cadc-uws-server/src/main/java/ca/nrc/cadc/uws/server/RemoteJobUpdater.java
+++ b/cadc-uws-server/src/main/java/ca/nrc/cadc/uws/server/RemoteJobUpdater.java
@@ -70,6 +70,7 @@
 package ca.nrc.cadc.uws.server;
 
 import ca.nrc.cadc.net.HttpDownload;
+import ca.nrc.cadc.net.TransientException;
 import ca.nrc.cadc.util.Base64;
 import ca.nrc.cadc.uws.ErrorSummary;
 import ca.nrc.cadc.uws.ExecutionPhase;
@@ -260,7 +261,7 @@ public class RemoteJobUpdater implements JobUpdater
      * @throws TransientException
      */
     public void addParameters(String jobID, List<Parameter> params)
-        throws JobNotFoundException
+        throws JobNotFoundException, JobPersistenceException, TransientException
     {
         throw new UnsupportedOperationException("addParameters() not implemented in RemoteJobUpdater.");
     }

--- a/cadc-uws-server/src/main/java/ca/nrc/cadc/uws/server/RemoteJobUpdater.java
+++ b/cadc-uws-server/src/main/java/ca/nrc/cadc/uws/server/RemoteJobUpdater.java
@@ -3,7 +3,7 @@
 *******************  CANADIAN ASTRONOMY DATA CENTRE  *******************
 **************  CENTRE CANADIEN DE DONNÉES ASTRONOMIQUES  **************
 *
-*  (c) 2011.                            (c) 2011.
+*  (c) 2022.                            (c) 2022.
 *  Government of Canada                 Gouvernement du Canada
 *  National Research Council            Conseil national de recherches
 *  Ottawa, Canada, K1A 0R6              Ottawa, Canada, K1A 0R6
@@ -73,6 +73,7 @@ import ca.nrc.cadc.net.HttpDownload;
 import ca.nrc.cadc.util.Base64;
 import ca.nrc.cadc.uws.ErrorSummary;
 import ca.nrc.cadc.uws.ExecutionPhase;
+import ca.nrc.cadc.uws.Parameter;
 import ca.nrc.cadc.uws.Result;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
@@ -248,4 +249,20 @@ public class RemoteJobUpdater implements JobUpdater
             throw new JobPersistenceException("failed to update job " + jobID, ex);
         }
     }
+
+    /**
+     * Add parameters to the specified job.
+     *
+     * @param jobID
+     * @param params
+     * @throws JobNotFoundException
+     * @throws JobPersistenceException
+     * @throws TransientException
+     */
+    public void addParameters(String jobID, List<Parameter> params)
+        throws JobNotFoundException
+    {
+        throw new UnsupportedOperationException("addParameters() not implemented in RemoteJobUpdater.");
+    }
+
 }

--- a/cadc-uws-server/src/test/java/ca/nrc/cadc/uws/server/ThreadExecutorTest.java
+++ b/cadc-uws-server/src/test/java/ca/nrc/cadc/uws/server/ThreadExecutorTest.java
@@ -3,7 +3,7 @@
 *******************  CANADIAN ASTRONOMY DATA CENTRE  *******************
 **************  CENTRE CANADIEN DE DONNÉES ASTRONOMIQUES  **************
 *
-*  (c) 2011.                            (c) 2011.
+*  (c) 2022.                            (c) 2022.
 *  Government of Canada                 Gouvernement du Canada
 *  National Research Council            Conseil national de recherches
 *  Ottawa, Canada, K1A 0R6              Ottawa, Canada, K1A 0R6
@@ -74,6 +74,7 @@ import ca.nrc.cadc.util.Log4jInit;
 import ca.nrc.cadc.uws.ErrorSummary;
 import ca.nrc.cadc.uws.ExecutionPhase;
 import ca.nrc.cadc.uws.Job;
+import ca.nrc.cadc.uws.Parameter;
 import ca.nrc.cadc.uws.Result;
 import java.util.Date;
 import java.util.HashMap;
@@ -267,6 +268,11 @@ public class ThreadExecutorTest
         public ExecutionPhase setPhase(String jobID, ExecutionPhase start, ExecutionPhase end, ErrorSummary error, Date date) throws JobNotFoundException, JobPersistenceException
         {
             return setPhase(jobID, start, end);
+        }
+
+        public void addParameters(String jobID, List<Parameter> params) throws JobNotFoundException
+        {
+            throw new UnsupportedOperationException("addParameters() not implemented in TestJobUpdater");
         }
     }
     


### PR DESCRIPTION
Makes that function available through the JobUpdater in cadc-vos-server (or anywhere else.) 