### PR TITLE
cadc-uws-server: Adjust logic in job list handling to fix issue with repeated entries

### DIFF
--- a/cadc-uws-server/build.gradle
+++ b/cadc-uws-server/build.gradle
@@ -15,7 +15,7 @@ sourceCompatibility = 1.8
 
 group = 'org.opencadc'
 
-version = '1.2.23'
+version = '1.2.24'
 
 description = 'OpenCADC UWS server library'
 def git_url = 'https://github.com/opencadc/uws'


### PR DESCRIPTION
## Description
There was a bug in `JobListIterator` where the pagination was returning the same job repeatedly when the query param LAST was requesting more jobs than available for a given user.

The original code was updating pagination state (lastJobID/lastCreationTime) before filtering out duplicates, which seemed to be causing the iterator to get stuck repeating the same entry.

## Changes
- Restructured pagination logic in `getNextBatchIterator()` to handle duplicates before updating state
- Added proper handling of edge cases for jobs with identical timestamps

## Testing
This version was built and deployed at the environment and tested with the use-case scenario where the error occurs, confirming  that this addresses the bug.

Let me know if this fix makes sense, or if you'd like any adjustments made
